### PR TITLE
Clear input after closing `NewListDialog`

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -225,3 +225,25 @@ test("initializes state with data from localStorage", () => {
   fireEvent.click(screen.getByRole("link"));
   expect(screen.getByText(/tomatoes from localStorage/i)).toBeInTheDocument();
 });
+
+test("clears the input of the `NewListDialog`", () => {
+  render(
+    <MemoryRouter>
+      <App />
+    </MemoryRouter>
+  );
+
+  fireEvent.click(screen.getByTitle(/create new list/i));
+  fireEvent.change(screen.getByRole("textbox"), { target: { value: "List #1" } });
+  fireEvent.keyDown(document, { key: "Escape" });
+  expect(screen.queryByTitle(/create list/i)).not.toBeInTheDocument();
+  fireEvent.keyDown(document, { key: "Escape" });
+  expect(screen.queryByTitle(/create list/i)).not.toBeInTheDocument();
+  fireEvent.click(screen.getByTitle(/create new list/i));
+  expect(screen.getByRole("textbox")).toHaveValue("");
+  fireEvent.change(screen.getByRole("textbox"), { target: { value: "List #1" } });
+  fireEvent.click(screen.getByTitle(/create list/i));
+  fireEvent.click(screen.getByTitle(/back/i));
+  fireEvent.click(screen.getByTitle(/create new list/i));
+  expect(screen.getByRole("textbox")).toHaveValue("");
+});

--- a/src/components/NewListDialog.test.tsx
+++ b/src/components/NewListDialog.test.tsx
@@ -35,7 +35,7 @@ test("renders a form with a label, input, and buttons", () => {
   expect(screen.getByTitle(/cancel/i)).toBeInTheDocument();
 });
 
-test("it calls dispatch to create a new list", () => {
+test("calls dispatch to create a new list", () => {
   jest.useFakeTimers().setSystemTime(new Date("2020-01-01").getTime());
   const spy = jest.fn();
 
@@ -55,7 +55,7 @@ test("it calls dispatch to create a new list", () => {
   jest.useRealTimers();
 });
 
-test("it calls dispatch to hide the dialog", () => {
+test("calls dispatch to hide the dialog", () => {
   const spy = jest.fn();
 
   renderWithContext(<NewListDialog />, {

--- a/src/components/NewListDialog.tsx
+++ b/src/components/NewListDialog.tsx
@@ -31,12 +31,15 @@ function NewListDialog() {
       }
     }
 
-    document.addEventListener("keydown", handleKeyDown);
+    if (isNewListDialogVisible) {
+      document.addEventListener("keydown", handleKeyDown);
 
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [dispatch]);
+      return () => {
+        setName("");
+        document.removeEventListener("keydown", handleKeyDown);
+      };
+    }
+  }, [dispatch, isNewListDialogVisible]);
 
   if (!isNewListDialogVisible) {
     return null;


### PR DESCRIPTION
Correctly dispose event listener when closing the input

Closes #89 
Closes #109 